### PR TITLE
Fix malformed XML

### DIFF
--- a/releases/Flicky.mra
+++ b/releases/Flicky.mra
@@ -5,7 +5,7 @@
 	<mratimestamp>202001070000</mratimestamp>
 	<year>1984</year>
 	<manufacturer>Sega</manufacturer>
-	<category>Maze / Cat & Mouse</category>
+	<category>Maze / Cat &amp; Mouse</category>
 	<category>Platform</category>
 	<rbf>segasys1</rbf>
     <switches default="FF,7C">


### PR DESCRIPTION
> The ampersand character (&) and the left angle bracket (<) must not appear in their literal form, except when used as markup delimiters, or within a comment, a processing instruction, or a CDATA section. If they are needed elsewhere, they must be escaped using either numeric character references or the strings " &amp; " and " &lt; " respectively.

source: https://www.w3.org/TR/xml/#syntax